### PR TITLE
Add GH Actions to build on PR and cron

### DIFF
--- a/.github/workflows/test-rosbag2_bag_v2.yml
+++ b/.github/workflows/test-rosbag2_bag_v2.yml
@@ -1,0 +1,24 @@
+name: Test rosbag2_bag_v2
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  build_and_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, ubuntu-18.04]
+    steps:
+      - uses: ros-tooling/setup-ros2@master
+      - uses: ros-tooling/action-ros2-ci@master
+        with:
+          package-name: rosbag2_bag_v2
+
+

--- a/.github/workflows/test-rosbag2_bag_v2.yml
+++ b/.github/workflows/test-rosbag2_bag_v2.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: ros-tooling/setup-ros2@master
       - uses: ros-tooling/action-ros2-ci@master
         with:
-          package-name: rosbag2_bag_v2
+          package-name: rosbag2_bag_v2_plugins
 
 


### PR DESCRIPTION
Adds in GH Actions CI to repository.
Runs build and test for `macOS-latest` and `ubuntu-18.04` on PR, push to master, and hourly cron.