### PR TITLE
Add GitHub Actions for linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+# Run linters automatically on pull requests.
+name: Lint rosbag2_bag_v2
+on:
+  pull_request:
+
+jobs:
+  ament_copyright:
+    name: ament_copyright
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: copyright
+        package-name: |
+            ros1_rosbag_storage_vendor
+            rosbag2_bag_v2_plugins
+
+  ament_xmllint:
+    name: ament_xmllint
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: xmllint
+        package-name: |
+            ros1_rosbag_storage_vendor
+            rosbag2_bag_v2_plugins
+
+  ament_lint_cpp: # Linters applicable to C++ packages
+    name: ament_${{ matrix.linter }}
+    runs-on: ubuntu-18.04
+    strategy:
+      fail-fast: false
+      matrix:
+          linter: [cppcheck, cpplint, uncrustify]
+    steps:
+    - uses: actions/checkout@v1
+    - uses: ros-tooling/setup-ros2@0.0.7
+    - uses: ros-tooling/action-ros2-lint@0.0.5
+      with:
+        linter: ${{ matrix.linter }}
+        package-name: |
+            ros1_rosbag_storage_vendor
+            rosbag2_bag_v2_plugins


### PR DESCRIPTION
### Changes

* Add ROS2 GitHub Actions linters (ament_copyright, ament_xmllint, ament_lint_cpp) to project.
* Similar work was done to rosbag2 here: ros2/rosbag2#227

### Issues
* Old PR: https://github.com/ros2/rosbag2_bag_v2/pull/12

Signed-off-by: Zachary Michaels <zmichaels11@gmail.com>