### PR TITLE
Use rosbag2 metapackage

### DIFF
--- a/rosbag2_bag_v2_plugins/CMakeLists.txt
+++ b/rosbag2_bag_v2_plugins/CMakeLists.txt
@@ -114,7 +114,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
   ROSBAG2_BAG_V2_PLUGINS_BUILDING_DLL)
 
 pluginlib_export_plugin_description_file(rosbag2_storage storage_plugin_description.xml)
-pluginlib_export_plugin_description_file(rosbag2 converter_plugin_description.xml)
+pluginlib_export_plugin_description_file(rosbag2_cpp converter_plugin_description.xml)
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/rosbag2_bag_v2_plugins/CMakeLists.txt
+++ b/rosbag2_bag_v2_plugins/CMakeLists.txt
@@ -34,8 +34,9 @@ endif()
 
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
-find_package(rosbag2 REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
 find_package(rosbag2_storage REQUIRED)
 find_package(ros1_rosbag_storage REQUIRED)  # provided by ros1_rosbag_storage_vendor
 
@@ -83,8 +84,8 @@ add_library(
 ament_target_dependencies(${PROJECT_NAME}
   ros1_rosbag_storage
   rclcpp
+  rosbag2_cpp
   rosbag2_storage
-  rosbag2
   ros1_bridge
   pluginlib
   ros1_cpp_common

--- a/rosbag2_bag_v2_plugins/converter_plugin_description.xml
+++ b/rosbag2_bag_v2_plugins/converter_plugin_description.xml
@@ -2,7 +2,7 @@
     <class
             name="rosbag_v2_converter"
             type="rosbag2_bag_v2_plugins::RosbagV2Deserializer"
-            base_class_type="rosbag2::converter_interfaces::SerializationFormatDeserializer"
+            base_class_type="rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer"
     >
         <description>
             This is a deserializer plugin which allows to convert ROS 1 messages via the

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/convert_rosbag_message.cpp.em
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/convert_rosbag_message.cpp.em
@@ -27,8 +27,8 @@ from ros1_bridge import camel_case_to_lower_case_underscore
 #include "rclcpp/rclcpp.hpp"
 #include "rcutils/allocator.h"
 #include "rosbag2_storage/ros_helper.hpp"
-#include "rosbag2/typesupport_helpers.hpp"
-#include "rosbag2/types/introspection_message.hpp"
+#include "rosbag2_cpp/typesupport_helpers.hpp"
+#include "rosbag2_cpp/types/introspection_message.hpp"
 
 @[for m in mappings]@
 #include "@(m.ros1_msg.package_name)/@(m.ros1_msg.message_name).h"
@@ -47,7 +47,7 @@ void
 convert_1_to_2(
   const std::string & ros1_type_name,
   ros::serialization::IStream & ros1_message_stream,
-  std::shared_ptr<rosbag2_introspection_message_t> ros2_message)
+  std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> ros2_message)
 {
   @[if not mappings]@
   (void) ros1_type_name;

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/convert_rosbag_message.hpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/convert_rosbag_message.hpp
@@ -19,8 +19,7 @@
 #include <string>
 
 #include "rosbag/message_instance.h"
-#include "rosbag2/types.hpp"
-#include "rosbag2/types/introspection_message.hpp"
+#include "rosbag2_cpp/types/introspection_message.hpp"
 
 namespace rosbag2_bag_v2_plugins
 {
@@ -30,7 +29,7 @@ void
 convert_1_to_2(
   const std::string & ros1_type_name,
   ros::serialization::IStream & ros1_message_stream,
-  std::shared_ptr<rosbag2_introspection_message_t> ros2_message);
+  std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> ros2_message);
 }  // namespace rosbag2_bag_v2_plugins
 
 #endif  // ROSBAG2_BAG_V2_PLUGINS__CONVERT_ROSBAG_MESSAGE_HPP_

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.cpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.cpp
@@ -21,7 +21,9 @@
 
 #include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
 #include "rosbag2_cpp/types/introspection_message.hpp"
+
 #include "rosbag2_storage/serialized_bag_message.hpp"
+
 #include "../convert_rosbag_message.hpp"
 
 namespace rosbag2_bag_v2_plugins

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.cpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.cpp
@@ -19,16 +19,17 @@
 
 #include "rosbag/message_instance.h"
 
-#include "rosbag2/converter_interfaces/serialization_format_deserializer.hpp"
-#include "rosbag2/types/introspection_message.hpp"
+#include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
+#include "rosbag2_cpp/types/introspection_message.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
 #include "../convert_rosbag_message.hpp"
 
 namespace rosbag2_bag_v2_plugins
 {
 void RosbagV2Deserializer::deserialize(
-  std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
+  std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message,
   const rosidl_message_type_support_t * type_support,
-  std::shared_ptr<rosbag2_introspection_message_t> ros_message)
+  std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> ros_message)
 {
   (void) type_support;
 
@@ -46,11 +47,11 @@ void RosbagV2Deserializer::deserialize(
   convert_1_to_2(ros1_data_type, stream, ros_message);
 
   ros_message->time_stamp = serialized_message->time_stamp;
-  rosbag2::introspection_message_set_topic_name(
+  rosbag2_cpp::introspection_message_set_topic_name(
     ros_message.get(), serialized_message->topic_name.c_str());
 }
 }  // namespace rosbag2_bag_v2_plugins
 
 #include "pluginlib/class_list_macros.hpp"  // NOLINT
 PLUGINLIB_EXPORT_CLASS(rosbag2_bag_v2_plugins::RosbagV2Deserializer,
-  rosbag2::converter_interfaces::SerializationFormatDeserializer)
+  rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer)

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
@@ -19,6 +19,7 @@
 
 #include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
 #include "rosbag2_cpp/types/introspection_message.hpp"
+
 #include "rosbag2_storage/serialized_bag_message.hpp"
 
 namespace rosbag2_bag_v2_plugins

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
@@ -17,22 +17,22 @@
 
 #include <memory>
 
-#include "rosbag2/converter_interfaces/serialization_format_deserializer.hpp"
-#include "rosbag2/types.hpp"
-#include "rosbag2/types/introspection_message.hpp"
+#include "rosbag2_cpp/converter_interfaces/serialization_format_deserializer.hpp"
+#include "rosbag2_cpp/types/introspection_message.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
 
 namespace rosbag2_bag_v2_plugins
 {
-class RosbagV2Deserializer : public rosbag2::converter_interfaces::SerializationFormatDeserializer
+class RosbagV2Deserializer : public rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer
 {
 public:
   RosbagV2Deserializer() = default;
   virtual ~RosbagV2Deserializer() = default;
 
   void deserialize(
-    std::shared_ptr<const rosbag2::SerializedBagMessage> serialized_message,
+    std::shared_ptr<const rosbag2_storage::SerializedBagMessage> serialized_message,
     const rosidl_message_type_support_t * type_support,
-    std::shared_ptr<rosbag2_introspection_message_t> ros_message) override;
+    std::shared_ptr<rosbag2_cpp::rosbag2_introspection_message_t> ros_message) override;
 };
 
 }  // namespace rosbag2_bag_v2_plugins

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/converter/rosbag_v2_deserializer.hpp
@@ -23,7 +23,8 @@
 
 namespace rosbag2_bag_v2_plugins
 {
-class RosbagV2Deserializer : public rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer
+class RosbagV2Deserializer
+  : public rosbag2_cpp::converter_interfaces::SerializationFormatDeserializer
 {
 public:
   RosbagV2Deserializer() = default;

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/storage/rosbag_v2_storage.cpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/storage/rosbag_v2_storage.cpp
@@ -19,10 +19,14 @@
 #include <vector>
 #include <utility>
 
+#include "rcpputils/filesystem_helper.hpp"
+#include "rcutils/filesystem.h"
 #include "rosbag/message_instance.h"
 
-#include "rosbag2_storage/filesystem_helper.hpp"
+#include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/ros_helper.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag_output_stream.hpp"
 #include "../logging.hpp"
 #include "../convert_rosbag_message.hpp"
@@ -116,12 +120,12 @@ std::string RosbagV2Storage::get_storage_identifier() const
 
 uint64_t RosbagV2Storage::get_bagfile_size() const
 {
-  return rosbag2_storage::FilesystemHelper::get_file_size(ros_v2_bag_->getFileName());
+  return rcutils_get_file_size(ros_v2_bag_->getFileName().c_str());
 }
 
 std::string RosbagV2Storage::get_relative_file_path() const
 {
-  return rosbag2_storage::FilesystemHelper::get_file_name(ros_v2_bag_->getFileName());
+  return rcpputils::fs::path(ros_v2_bag_->getFileName()).filename().string();
 }
 
 rosbag2_storage::BagMetadata RosbagV2Storage::get_metadata()
@@ -129,6 +133,7 @@ rosbag2_storage::BagMetadata RosbagV2Storage::get_metadata()
   auto bag_view = std::make_unique<rosbag::View>(*ros_v2_bag_);
   auto full_file_path = ros_v2_bag_->getFileName();
   rosbag2_storage::BagMetadata metadata;
+  metadata.version = 2;
   metadata.storage_identifier = get_storage_identifier();
   metadata.bag_size = get_bagfile_size();
   metadata.relative_file_paths = {get_relative_file_path()};

--- a/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/storage/rosbag_v2_storage.hpp
+++ b/rosbag2_bag_v2_plugins/src/rosbag2_bag_v2_plugins/storage/rosbag_v2_storage.hpp
@@ -19,7 +19,10 @@
 #include <string>
 #include <vector>
 
+#include "rosbag2_storage/bag_metadata.hpp"
 #include "rosbag2_storage/storage_interfaces/read_only_interface.hpp"
+#include "rosbag2_storage/serialized_bag_message.hpp"
+#include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag/bag.h"
 #include "rosbag/view.h"
 

--- a/rosbag2_bag_v2_plugins/test/rosbag2_bag_v2_plugins/rosbag_v2_storage_test_fixture.hpp
+++ b/rosbag2_bag_v2_plugins/test/rosbag2_bag_v2_plugins/rosbag_v2_storage_test_fixture.hpp
@@ -18,9 +18,9 @@
 #include <memory>
 #include <string>
 
+#include "rcpputils/filesystem_helper.hpp"
 #include "rosbag2_test_common/temporary_directory_fixture.hpp"
 #include "rosbag2_storage/serialized_bag_message.hpp"
-#include "rosbag2_storage/filesystem_helper.hpp"
 #include "../../src/rosbag2_bag_v2_plugins/storage/rosbag_v2_storage.hpp"
 #include "rosbag/bag.h"
 #include "rosbag/view.h"
@@ -33,7 +33,7 @@ public:
   RosbagV2StorageTestFixture()
   {
     database_path_ = _SRC_RESOURCES_DIR_PATH;  // variable defined in CMakeLists.txt
-    bag_path_ = rosbag2_storage::FilesystemHelper::concat({database_path_, "test_bag.bag"});
+    bag_path_ = (rcpputils::fs::path(database_path_) / "test_bag.bag").string();
     storage_ = std::make_shared<rosbag2_bag_v2_plugins::RosbagV2Storage>();
     storage_->open(bag_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
   }

--- a/rosbag2_bag_v2_plugins/test/rosbag2_bag_v2_plugins/test_rosbag_v2_storage.cpp
+++ b/rosbag2_bag_v2_plugins/test/rosbag2_bag_v2_plugins/test_rosbag_v2_storage.cpp
@@ -20,7 +20,7 @@
 #include <tuple>
 #include <vector>
 
-#include "rosbag2_storage/filesystem_helper.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 #include "rosbag2_storage/topic_metadata.hpp"
 #include "rosbag_v2_storage_test_fixture.hpp"
 
@@ -125,8 +125,7 @@ TEST_F(RosbagV2StorageTestFixture, read_next_will_produce_messages_ordered_by_ti
 
 TEST_F(RosbagV2StorageTestFixture, get_topics_and_types_will_only_return_one_entry_per_topic)
 {
-  bag_path_ = rosbag2_storage::FilesystemHelper::concat(
-    {database_path_, "test_bag_multiple_connections.bag"});
+  bag_path_ = (rcpputils::fs::path(database_path_) / "test_bag_multiple_connections.bag").string();
   storage_ = std::make_shared<rosbag2_bag_v2_plugins::RosbagV2Storage>();
   storage_->open(bag_path_, rosbag2_storage::storage_interfaces::IOFlag::READ_ONLY);
 


### PR DESCRIPTION
### Changes
* Update codebase to support removal of FilesystemHelper (https://github.com/ros2/rosbag2/pull/249)
* Update codebase to support Rosbag2 as a metapackage (https://github.com/ros2/rosbag2/pull/241)

Blocked on https://github.com/ros2/rosbag2/issues/253 since play e2e test is failing.