### PR TITLE
Raise an error instead of a warning without ROS 1

### DIFF
--- a/rosbag2_bag_v2_plugins/CMakeLists.txt
+++ b/rosbag2_bag_v2_plugins/CMakeLists.txt
@@ -20,12 +20,12 @@ find_package(ament_cmake REQUIRED)
 # include bridge first to not create package if ros1 packages cannot be found
 find_package(ros1_bridge QUIET)
 if(NOT ros1_bridge_FOUND)
-  message(FATAL_ERROR "Failed to find ros1_bridge, skipping...")
+  message(FATAL_ERROR "Failed to find ros1_bridge, cannot build.")
 endif()
 
 find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
-  message(FATAL_ERROR "Failed to find ROS 1 roscpp, skipping...")
+  message(FATAL_ERROR "Failed to find ROS 1 roscpp, cannot build.")
 endif()
 
 find_package(pluginlib REQUIRED)

--- a/rosbag2_bag_v2_plugins/CMakeLists.txt
+++ b/rosbag2_bag_v2_plugins/CMakeLists.txt
@@ -20,16 +20,12 @@ find_package(ament_cmake REQUIRED)
 # include bridge first to not create package if ros1 packages cannot be found
 find_package(ros1_bridge QUIET)
 if(NOT ros1_bridge_FOUND)
-  message(WARNING "Failed to find ros1_bridge, skipping...")
-  # call ament_package() to avoid ament_tools treating this as a plain CMake pkg
-  ament_package()
-  return()
+  message(FATAL_ERROR "Failed to find ros1_bridge, skipping...")
 endif()
+
 find_ros1_package(roscpp)
 if(NOT ros1_roscpp_FOUND)
-  message(WARNING "Failed to find ROS 1 roscpp, skipping...")
-  ament_package()
-  return()
+  message(FATAL_ERROR "Failed to find ROS 1 roscpp, skipping...")
 endif()
 
 find_package(pluginlib REQUIRED)


### PR DESCRIPTION
When ROS 1 `roscpp` and the `ros1_bridge` are not installed, this can't actually build. 

Closes #13 

Please see the brief conversation in #13 for more info - basically there's no reason to pretend to succeed, since this is not part of the standard `ros2.repos`