### PR TITLE
workaround add shared_queues_vendor as test dependency

### DIFF
--- a/rosbag2_bag_v2_plugins/CMakeLists.txt
+++ b/rosbag2_bag_v2_plugins/CMakeLists.txt
@@ -127,6 +127,8 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(rosbag2_test_common REQUIRED)
   find_package(rosbag2_transport REQUIRED)
+  find_package(shared_queues_vendor REQUIRED)
+
 
   ament_lint_auto_find_test_dependencies()
 

--- a/rosbag2_bag_v2_plugins/package.xml
+++ b/rosbag2_bag_v2_plugins/package.xml
@@ -21,6 +21,7 @@
   <test_depend>ament_cmake_gmock</test_depend>
   <test_depend>rosbag2_test_common</test_depend>
   <test_depend>rosbag2_transport</test_depend>
+  <test_depend>shared_queues_vendor</test_depend>
   <test_depend>std_msgs</test_depend>
 
   <export>


### PR DESCRIPTION
temporary workaround until https://github.com/ros2/rosbag2/issues/433 is addressed. That should be revoked when done.